### PR TITLE
Moving to eth-sig-util to achieve broad interoperability

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "ecmaVersion": 2017
   },
   "rules": {
-    "no-underscore-dangle": "off"
+    "no-underscore-dangle": "off",
+    "max-len": 1
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@linniaprotocol/linnia-js",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3345,6 +3345,53 @@
         "servify": "^0.1.12",
         "ws": "^3.0.0",
         "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "eth-sig-util": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.1.0.tgz",
+      "integrity": "sha512-JRKmq1zytYoOuAj8llYiGlRGSlWrQ0jGGh9+YPhELfmMP1PD/dkwq2kzMoB8pRF6sEgZojQfSasswto3xsKFvw==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "elliptic": "^6.4.0",
+        "ethereumjs-abi": "0.6.5",
+        "ethereumjs-util": "^5.1.1",
+        "tweetnacl": "^1.0.0",
+        "tweetnacl-util": "^0.15.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
+      }
+    },
+    "ethereumjs-abi": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+      "requires": {
+        "bn.js": "^4.10.0",
+        "ethereumjs-util": "^4.3.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+          "requires": {
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "keccakjs": "^0.2.0",
+            "rlp": "^2.0.0",
+            "secp256k1": "^3.0.1"
+          }
+        }
       }
     },
     "ethereumjs-util": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@linniaprotocol/linnia-smart-contracts": "^0.1.1",
     "babel-runtime": "^6.26.0",
     "bignumber.js": "^7.2.1",
+    "eth-sig-util": "^2.1.0",
     "ethereumjs-util": "^5.2.0",
     "truffle-contract": "3.0.5",
     "tweetnacl": "^1.0.0",

--- a/test/1-util-test.js
+++ b/test/1-util-test.js
@@ -57,13 +57,13 @@ describe('Encryption Scheme', () => {
     it('should fail when encrypt with bad key', () => {
       const data = 'foo';
       const pubKey2 = 'hQYhHJSjkL17VGyNTHNQY=';
-      assert.throws(() => Linnia.util.encrypt(pubKey2, data), Error, "invalid encoding");
+      assert.throws(() => Linnia.util.encrypt(pubKey2, data), Error, "Bad public key");
     });
     it('should fail when decrypt with wrong key', () => {
       const data = 'foo';
       const privWrongKey = '5VdzPXk23HBA+S1tcSsSFGxjPpsHgQ5PMx3tbfsxSIU=';
       const ct = Linnia.util.encrypt(pubKey1, data);
-      assert.throws(() => Linnia.util.decrypt(privWrongKey, ct), Error, "Decryption failed");
+      assert.throws(() => Linnia.util.decrypt(privWrongKey, ct), Error, "Decryption failed.");
     });
     it('should fail when decrypt with empty key', () => {
       const data = 'foo';
@@ -78,7 +78,7 @@ describe('Encryption Scheme', () => {
       const data = 'foo';
       const ct = Linnia.util.encrypt(pubKey1, data);
       ct.version = 'foobar';
-      assert.throws(() => Linnia.util.decrypt(privKey1, ct), Error, `Decryption failed: Version [${ct.version}] is not supproted.`);
+      assert.throws(() => Linnia.util.decrypt(privKey1, ct), Error, 'Encryption type/version not supported.');
     });
   });
 });


### PR DESCRIPTION
This makes our code much cleaning and ensures that we are compatible with a number of projects that already use eth-sig-util including metamask, civil, Aragon and radian.